### PR TITLE
Removed mandatory prefix from storage key.

### DIFF
--- a/libs/ngx-localstorage/src/lib/services/ngx-localstorage.service.ts
+++ b/libs/ngx-localstorage/src/lib/services/ngx-localstorage.service.ts
@@ -67,7 +67,11 @@ export class LocalStorageService {
         value !== null &&
         value !== undefined)
     ) {
-      localStorage.setItem(`${prefix || this._prefix}_${key}`, value);
+      if (prefix || this._prefix) {
+        localStorage.setItem(`${prefix || this._prefix}_${key}`, value);
+      } else {
+        localStorage.setItem(key, value);
+      }
     } else {
       this.remove(key, prefix);
     }
@@ -80,7 +84,11 @@ export class LocalStorageService {
    */
   get(key: string, prefix?: string): string | null | undefined {
     try {
-      return localStorage.getItem(`${prefix || this._prefix}_${key}`);
+      if (prefix || this._prefix) {
+        return localStorage.getItem(`${prefix || this._prefix}_${key}`);
+      } else {
+        return localStorage.getItem(key);
+      }
     } catch (error) {
       console.error(error);
     }
@@ -93,7 +101,11 @@ export class LocalStorageService {
    */
   remove(key: string, prefix?: string): void {
     try {
-      localStorage.removeItem(`${prefix || this._prefix}_${key}`);
+      if (prefix || this._prefix) {
+        localStorage.removeItem(`${prefix || this._prefix}_${key}`);
+      } else {
+        localStorage.removeItem(key);
+      }
     } catch (error) {
       console.error(error);
     }


### PR DESCRIPTION
Say I initialize the storage module without a prefix key:

```typescript
@NgModule({
  declarations: [
    AppComponent
  ],
  imports: [
    NgxLocalStorageModule.forRoot({ prefix: '' }),
  ],
})
export class AppModule {}
```

Keys will be prefixed regardless as `undefined_`. In ES6 string interpolation, `undefined` outputs literally when supplied. Give `key = 'magic_sparkles'` and `prefix = undefined`:

    `${prefix}_${key}` -> undefined_magic_sparkles

If I supply a null or falsy `prefix`, what I expect to see is

    'magic_sparkles' -> magic_sparkles

This commit modifies storage service getters and setters in order to only output a key prefix when it has a truthy value.
